### PR TITLE
requiring react, not react-native

### DIFF
--- a/Canvas.js
+++ b/Canvas.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
   View,
   WebView


### PR DESCRIPTION
I think that this depends on whether you're using ES6 or CommonJS, but I'm using a buildpack that throws an error saying that I need to require `react`, not `react-native`. It might not matter with CommonJS, but I think it does with ES6. Something with namespacing maybe.